### PR TITLE
make the download work on windows too

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use this code to download the theme file straight into the RStudio themes direct
 ```r
 # I've only tested on Mac
 library(fs)
-rsthemes_dir <- path_home(".R", "rstudio", "themes")
+rsthemes_dir <- path_home_r(".R", "rstudio", "themes")
 dir_create(rsthemes_dir)
 download.file(
   "https://git.io/yule-rstudio",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ You'll need RStudio version 1.2. Grab the [preview version here](https://www.rst
 Use this code to download the theme file straight into the RStudio themes directory.
 
 ```r
-# I've only tested on Mac
 library(fs)
 rsthemes_dir <- path_home_r(".R", "rstudio", "themes")
 dir_create(rsthemes_dir)


### PR DESCRIPTION
The R and .R live in the ~/Documents folder on Windows. `path_home_r()` corrects for that. It should go to ~ on Mac, but you should check that.