### PR TITLE
Added color for .ace_invisible

### DIFF
--- a/Yule-RStudio.rstheme
+++ b/Yule-RStudio.rstheme
@@ -50,6 +50,10 @@
   font-weight: 700;
 }
 
+.ace_invisible {
+	color: rgba(150, 180, 130, 0.3);
+}
+
 .ace_constant.ace_language.ace_boolean.ace_text {
   font-style: italic;
 }


### PR DESCRIPTION
The .ace_invisible class refers to RStudio's whitespace characters. This is just a suggestion for what is perhaps a more common look for whitspace characters in RStudio. I'll add comparison screenshots in an issue.